### PR TITLE
家計状況登録・編集画面の教育費入力項目を非活性に修正

### DIFF
--- a/app/views/households/_form.html.erb
+++ b/app/views/households/_form.html.erb
@@ -35,7 +35,7 @@
             <p hidden><%= amount_form.text_field :expense_revenue_item_id %></p>
             <% if current_user.children.empty? %>
               <div>
-                <%= amount_form.text_field :amount, class: "form-control", value:0, readonly: true %>
+                <%= amount_form.text_field :amount, class: "form-control", value:0, disabled: true  %>
               </div>
               <div>
                 <small>0人のお子様の教育費</small><br>
@@ -74,7 +74,7 @@
             <p hidden><%= amount_form.text_field :expense_revenue_item_id %></p>
             <% if current_user.children.empty? %>
               <div>
-                <%= amount_form.text_field :amount, class: "form-control", value:0, readonly: true %>
+                <%= amount_form.text_field :amount, class: "form-control", value:0, disabled: true %>
               </div>
               <div>
                 <small>0人のお子様の教育費</small><br>


### PR DESCRIPTION
・5/26にメンターさんより「教育費の入力ができない」とのご指摘あり
・教育費は手動入力ではなく、子どもの人数に応じて教育費マスタより自動参照する仕様であるため、仕様としての誤りはないが、その仕様がわかりづらかったため項目を非活性とした