### PR TITLE
5/31メンター様からのご指摘事項を反映

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -76,16 +76,15 @@ class HouseholdsController < ApplicationController
         format.json { render :show, status: :created, location: @household }
       else
         # @householdの情報からバリデーションエラーが発生した収支項目を特定することができないため、以下の(1)~(3)のparamsの情報からエラーが発生した収支項目一覧を作成する
-        # (1)全収支項目のidを取得するため、ExpenseRevunueItemテーブルにある全idを配列として取得
-        expense_revenue_item_id_list = ExpenseRevenueItem.select("id").map { |item| item.id }
+        # (1)全収支項目のidとnameを取得するため、ExpenseRevunueItemテーブルにある全idとnameを配列として取得
+        expense_revenue_item_id_name_list = ExpenseRevenueItem.select("id,name").map { |item| [item.id, item.name] }
         # (2)エラーが発生した収支項目一覧の作成
         @error_item_list = []
         # (3)収支項目のうち、金額の値が未入力（＝空白）のものを特定し、その収支項目名を取得し、(2)の配列に追加する
-        expense_revenue_item_id_list.each do |item_id|
-          id = (item_id - 1).to_s
+        expense_revenue_item_id_name_list.each do |item|
+          id = (item.first - 1).to_s
           if params[:household][:expense_revenue_amounts_attributes][id][:amount] == ""
-            name = ExpenseRevenueItem.find(params[:household][:expense_revenue_amounts_attributes][id][:expense_revenue_item_id]).name
-            @error_item_list.push(name)
+            @error_item_list.push(item.second)
           else
           end
         end
@@ -102,16 +101,15 @@ class HouseholdsController < ApplicationController
         format.json { render :show, status: :ok, location: @household }
       else
         # @householdの情報からバリデーションエラーが発生した収支項目を特定することができないため、以下の(1)~(3)のparamsの情報からエラーが発生した収支項目一覧を作成する
-        # (1)全収支項目のidを取得するため、ExpenseRevunueItemテーブルにある全idを配列として取得
-        expense_revenue_item_id_list = ExpenseRevenueItem.select("id").map { |item| item.id }
+        # (1)全収支項目のidとnameを取得するため、ExpenseRevunueItemテーブルにある全idとnameを配列として取得
+        expense_revenue_item_id_name_list = ExpenseRevenueItem.select("id,name").map { |item| [item.id, item.name] }
         # (2)エラーが発生した収支項目一覧の作成
         @error_item_list = []
         # (3)収支項目のうち、金額の値が未入力（＝空白）のものを特定し、その収支項目名を取得し、(2)の配列に追加する
-        expense_revenue_item_id_list.each do |item_id|
-          id = (item_id - 1).to_s
+        expense_revenue_item_id_name_list.each do |item|
+          id = (item.first - 1).to_s
           if params[:household][:expense_revenue_amounts_attributes][id][:amount] == ""
-            name = ExpenseRevenueItem.find(params[:household][:expense_revenue_amounts_attributes][id][:expense_revenue_item_id]).name
-            @error_item_list.push(name)
+            @error_item_list.push(item.second)
           else
           end
         end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -38,9 +38,9 @@ class PropertiesController < ApplicationController
         # 1.現金・貯蓄
         @cash_and_saving = @property.create_cash_and_saving_list(@household.joins_data_expense_revenue_amount_and_item(@household),@children)
         # 2-1.投資資産（ベストケース）
-        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.best_annual_interest_rate.truncate(2))
+        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.best_annual_interest_rate.truncate(2))
         # 2-2.投資資産（ワーストケース）
-        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.worst_annual_interest_rate.truncate(2))
+        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.worst_annual_interest_rate.truncate(2))
         # 3-1.使用資産（車）
         @car_property = @property.create_used_properties_list(@property.car_properties_present_value,@property.car_annual_residual_value_rate)
         # 3-2.使用資産（住宅）
@@ -48,11 +48,11 @@ class PropertiesController < ApplicationController
         # 3-3.使用資産（その他）
         @other_property = @property.create_used_properties_list(@property.other_properties_present_value,@property.other_annual_residual_value_rate)
         # 4-1.ローン（車）
-        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（車）"), @property.car_loan_interest_rate)
+        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（車）"), @property.car_loan_interest_rate)
         # 4-2.ローン（住宅）
-        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（住宅）"), @property.housing_loan_interest_rate)
+        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（住宅）"), @property.housing_loan_interest_rate)
         # 4-3.ローン（その他）
-        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（その他）"), @property.other_loan_interest_rate)
+        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（その他）"), @property.other_loan_interest_rate)
         # 純資産（ベストケース）
         @best_net_property = @property.create_net_property_list(@property,@household,@children,@property.best_annual_interest_rate.truncate(2))
         # 純資産（ワーストケース）
@@ -141,9 +141,9 @@ class PropertiesController < ApplicationController
         # 1.現金・貯蓄
         @cash_and_saving = @property.create_cash_and_saving_list(@household.joins_data_expense_revenue_amount_and_item(@household),@children)
         # 2-1.投資資産（ベストケース）
-        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.best_annual_interest_rate.truncate(2))
+        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.best_annual_interest_rate.truncate(2))
         # 2-2.投資資産（ワーストケース）
-        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.worst_annual_interest_rate.truncate(2))
+        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.worst_annual_interest_rate.truncate(2))
         # 3-1.使用資産（車）
         @car_property = @property.create_used_properties_list(@property.car_properties_present_value,@property.car_annual_residual_value_rate)
         # 3-2.使用資産（住宅）
@@ -151,11 +151,11 @@ class PropertiesController < ApplicationController
         # 3-3.使用資産（その他）
         @other_property = @property.create_used_properties_list(@property.other_properties_present_value,@property.other_annual_residual_value_rate)
         # 4-1.ローン（車）
-        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（車）"), @property.car_loan_interest_rate)
+        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（車）"), @property.car_loan_interest_rate)
         # 4-2.ローン（住宅）
-        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（住宅）"), @property.housing_loan_interest_rate)
+        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（住宅）"), @property.housing_loan_interest_rate)
         # 4-3.ローン（その他）
-        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（その他）"), @property.other_loan_interest_rate)
+        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（その他）"), @property.other_loan_interest_rate)
         # 純資産（ベストケース）
         @best_net_property = @property.create_net_property_list(@property,@household,@children,@property.best_annual_interest_rate.truncate(2))
         # 純資産（ワーストケース）
@@ -183,9 +183,9 @@ class PropertiesController < ApplicationController
         # 1.現金・貯蓄
         @cash_and_saving = @property.create_cash_and_saving_list(@household.joins_data_expense_revenue_amount_and_item(@household),@children)
         # 2-1.投資資産（ベストケース）
-        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.best_annual_interest_rate.truncate(2))
+        @best_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.best_annual_interest_rate.truncate(2))
         # 2-2.投資資産（ワーストケース）
-        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount(@household,"積立投資額"),@property.worst_annual_interest_rate.truncate(2))
+        @worst_investment_properties = @property.create_investment_list(@household.get_specific_expense_revenue_amount("積立投資額"),@property.worst_annual_interest_rate.truncate(2))
         # 3-1.使用資産（車）
         @car_property = @property.create_used_properties_list(@property.car_properties_present_value,@property.car_annual_residual_value_rate)
         # 3-2.使用資産（住宅）
@@ -193,11 +193,11 @@ class PropertiesController < ApplicationController
         # 3-3.使用資産（その他）
         @other_property = @property.create_used_properties_list(@property.other_properties_present_value,@property.other_annual_residual_value_rate)
         # 4-1.ローン（車）
-        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（車）"), @property.car_loan_interest_rate)
+        @car_loan = @property.create_loan_list(@property.car_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（車）"), @property.car_loan_interest_rate)
         # 4-2.ローン（住宅）
-        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（住宅）"), @property.housing_loan_interest_rate)
+        @housing_loan = @property.create_loan_list(@property.housing_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（住宅）"), @property.housing_loan_interest_rate)
         # 4-3.ローン（その他）
-        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount(@household,"ローン返済額（その他）"), @property.other_loan_interest_rate)
+        @other_loan = @property.create_loan_list(@property.other_present_loan_balance, @household.get_specific_expense_revenue_amount("ローン返済額（その他）"), @property.other_loan_interest_rate)
         # 純資産（ベストケース）
         @best_net_property = @property.create_net_property_list(@property,@household,@children,@property.best_annual_interest_rate.truncate(2))
         # 純資産（ワーストケース）

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -60,7 +60,7 @@ class Child < ApplicationRecord
         EducationExpense.joins(:child_educations).select("education_expenses.*, child_educations.child_id").where( child_educations:{child_id: child.id} )
     # 資産状況観測対象期間分の教育費用をeducation_expenses_of_every_education_institution_typeから参照し、education_expenses_listに順番に追加
     # education_expenses_of_every_education_institution_typeのうち、どの値を参照するかは子どもの年齢により判断する
-    Property.set_years_of_observation.times do
+    Property::YEARS_OF_OBSERVATION.times do
         # privateメソッドであるcalc_age_of_childメソッドより各年時点での子どもの年齢を算出
         age = Child.calc_age_of_child(base_year_month_day,child.birth_year_month_day)
 

--- a/app/models/education_expense.rb
+++ b/app/models/education_expense.rb
@@ -11,7 +11,7 @@ class EducationExpense < ApplicationRecord
 
     # enumの設定
     enum management_organization: { "公立": 1, "私立": 2 }
-    enum university_major: { "理系": 1, "文系": 2 }
+    enum university_major: { "なし": 0, "理系": 1, "文系": 2 }
     enum education_institution_type:{ "保育園": 1, "幼稚園": 2, "小学校": 3, "中学校": 4, "高校": 5, "専門学校": 6, "4年生大学": 7, "6年生大学": 8 }
     enum boarding_house:{"下宿なし": 0, "下宿あり": 1 }
 

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -26,8 +26,8 @@ class Household < ApplicationRecord
     # 資産状況のモデル、アクションで使用するメソッド
     # expense_revenue_amountsテーブルとexpense_revenue_itemテーブルを結合した上で指定の収支項目の金額を取得する
     # 任意のhouseholdに紐づくデータを抽出したいため、インスタンドメソッドとして作成
-    def get_specific_expense_revenue_amount(household,item_name)
-        return household.expense_revenue_amounts.joins(:expense_revenue_item).find_by(expense_revenue_item: {name: item_name}).amount
+    def get_specific_expense_revenue_amount(item_name)
+        return expense_revenue_amounts.joins(:expense_revenue_item).find_by(expense_revenue_item: {name: item_name}).amount
     end
 
     # 資産状況のモデル、アクションで使用するメソッド

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -293,9 +293,9 @@
         <div>
             <%= university.label "理系／文系" %>
             <% if child.child_educations.exists? %>
-                <%= university.collection_select :university_major, EducationExpense.select("university_major").distinct, :university_major, :university_major, selected: child.get_child_education_data(6..8, child).university_major %>
+                <%= university.collection_select :university_major, EducationExpense.select("university_major").where.not(university_major: "なし").distinct, :university_major, :university_major, selected: child.get_child_education_data(6..8, child).university_major %>
             <% else %>
-                <%= university.collection_select :university_major, EducationExpense.select("university_major").distinct, :university_major, :university_major, {}, id: "select_university_major_#{child.birth_order}" %>
+                <%= university.collection_select :university_major, EducationExpense.select("university_major").where.not(university_major: "なし").distinct, :university_major, :university_major, {}, id: "select_university_major_#{child.birth_order}" %>
             <% end %>
         </div>
 

--- a/spec/models/household_spec.rb
+++ b/spec/models/household_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Household, type: :model do
       FactoryBot.create(:expense_revenue_item1, household: household, expense_revenue_item: expense_revenue_item2, amount: 5000)
       FactoryBot.create(:expense_revenue_item1, household: household, expense_revenue_item: expense_revenue_item3, amount: 2000)
       # (4)引数に金額を参照したい収支項目名を指定し、テストデータとして定義した金額と一致するかを確認
-      expect(household.get_specific_expense_revenue_amount(household,expense_revenue_item1.name)).to eq 30000
+      expect(household.get_specific_expense_revenue_amount(expense_revenue_item1.name)).to eq 30000
     end
 
     it "expense_revenue_amountsテーブルとexpense_revenue_itemテーブルを結合するメソッド" do

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -62,11 +62,6 @@ RSpec.describe Property, type: :model do
       expect(result_get_property_id.id).to eq property.id
     end
 
-    it "資産状況を観察する年数を設定するメソッド" do
-      # 資産状況を観察する年数=60年なので、クラスメソッド「set_years_of_observation」が60と等しいことを確認
-      expect(Property.set_years_of_observation).to eq 60
-    end
-
     it "（★）資産状況テーブル表示用として60年間のうち、5年置きに年度を抽出して格納するためのメソッド" do
       # (1)Excelで今年(2024年)から60年間の年度のデータセットを作成の上、5年置きに年度を抽出したデータセットをローカル変数に格納
       expected_years_list_every_5years = file_fixture("expecte_years_list_every_5years.csv").read.split(',').map(&:to_i)
@@ -118,7 +113,7 @@ RSpec.describe Property, type: :model do
 
     it "投資資産額60年分のデータを作成するメソッド-投資利率が好調の場合を想定（=best_annual_interest_rate)" do
       expected_best_investment_property_list = file_fixture("expected_best_investment_property_list.csv").read.split(',').map(&:to_i)
-      actual_best_investment_property_list = property.create_investment_list(users_household.get_specific_expense_revenue_amount(users_household,"積立投資額"),property.best_annual_interest_rate.truncate(2))
+      actual_best_investment_property_list = property.create_investment_list(users_household.get_specific_expense_revenue_amount("積立投資額"),property.best_annual_interest_rate.truncate(2))
       actual_best_investment_property_list.each_with_index do |best_investment_property, index|
         expect(best_investment_property.round).to eq expected_best_investment_property_list[index]
       end          
@@ -134,7 +129,7 @@ RSpec.describe Property, type: :model do
 
     it "ローン60年分のデータを作成するメソッド-使用資産は「車」を想定" do
       expected_car_loan_list = file_fixture("expected_car_loan_list.csv").read.split(',').map(&:to_i)
-      actual_car_loan_list = property.create_loan_list(property.car_present_loan_balance, users_household.get_specific_expense_revenue_amount(users_household,"ローン返済額（車）"), property.car_loan_interest_rate)
+      actual_car_loan_list = property.create_loan_list(property.car_present_loan_balance, users_household.get_specific_expense_revenue_amount("ローン返済額（車）"), property.car_loan_interest_rate)
       actual_car_loan_list.each_with_index do |actual_car_loan, index|
         expect(actual_car_loan.round).to eq expected_car_loan_list[index]
       end          

--- a/spec/system/households_spec.rb
+++ b/spec/system/households_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "Households", type: :system do
       # 登録失敗した場合に、詳細画面には遷移せず、登録画面が表示されているかを画面タイトルから確認
       expect(page).to have_content("家計状況登録")
       # 登録失敗のメッセージが表示されているかを確認
-      expect(page).to have_content("いずれかの金額が未入力です")
+      expect(page).to have_content("医療費が未入力です")
     end
 
     it "（画面遷移テスト）「戻る」リンクを押下すると、家計状況一覧画面に遷移すること" do
@@ -316,7 +316,7 @@ RSpec.describe "Households", type: :system do
       # 登録失敗した場合に、詳細画面には遷移せず、登録画面が表示されているかを画面タイトルから確認
       expect(page).to have_content("家計状況編集")
       # 登録失敗のメッセージが表示されているかを確認
-      expect(page).to have_content("いずれかの金額が未入力です")
+      expect(page).to have_content("医療費が未入力です")
     end
 
     it "（画面遷移テスト）「戻る」リンクを押下すると、家計状況一覧画面に遷移すること" do


### PR DESCRIPTION
＜必須修正＞
①ご指摘内容：
education_expense.rbのenum:universuty_majorの「0:なし」を削除したことにより、子供の登録・seedファイルの実行・spec/models/education_expense_spec.rbのテストが失敗する
①の対応
・enum:universuty_majorの「0:なし」を追加
・子どもの登録フォーム（view/children/_form.html.erb）f.大学の理系／文系の選択肢として「なし」は表示させないように修正
・spec/models/education_expense_spec.rbのテストが実行できることを確認済み
・子どもの登録・更新ができることも確認済み

➁ご指摘内容：
get_specific_expense_revenue_amountメソッドについて、「インスタンスメソッドにするなら実行してるインスタンスがレシーバになるので引数で 自身を渡さなくても実行できるので引数を修正した方がいい」
➁の対応
・def get_specific_expense_revenue_amount(household,item_name)から引数householdを削除
・get_specific_expense_revenue_amountの呼び出しをしていた以下のファイルの引数を修正
　-household.rb
　-property.rb
　-properties_controller.rb
　-spec/models/household.rb
　-spec/models/property.rb
・-spec/models/household.rb、spec/models/property.rbのテスト再実行し、成功確認済み
・properties_controllerで修正したアクションを実行し、正常に動くこと確認済み

＜任意修正＞　
①ご指摘内容
households_controllerのExpenseRevenueItem.select("id").map { |item| [item.id](http://item.id/) }でidだけ取得するのではなくnameも事前に取得しておく
①の対応
・nameも取得できるように修正　※詳細は省略
・householdsのsystemテストを再実行し、成功確認済み

➁scope :set_years_of_observation, -> { 60 }はscopeではなく、定数として定義する
➁の対応
・定数（YEARS_OF_OBSERVATION = 60）で設定
・:set_years_of_observationを使っていた部分はProperty::YEARS_OF_OBSERVATIONに修正
・修正対応をしたモデルとそのモデルのRspecテストを再実行し、成功確認済み
